### PR TITLE
Support for small systems / SBCs

### DIFF
--- a/llm_benchmark/data/benchmark1.yml
+++ b/llm_benchmark/data/benchmark1.yml
@@ -15,6 +15,8 @@ modeltypes:
       - model: mistral:7b
       - model: llama3:8b
       - model: phi3:3.8b
+      - model: qwen:1.8b
+      - model: phi:2.7b
     prompts:
       - prompt: Write a step-by-step guide on how to bake a chocolate cake from scratch.
         keywords: cooking, recipe

--- a/llm_benchmark/data/benchmark_models_16gb_ram.yml
+++ b/llm_benchmark/data/benchmark_models_16gb_ram.yml
@@ -2,6 +2,8 @@
 # License: MIT
 version: 1.0
 models:
+  - model: qwen:1.8b
+  - model: phi:2.7b
   - model: gemma:2b
   - model: gemma:7b
   - model: mistral:7b

--- a/llm_benchmark/data/benchmark_models_2gb_ram.yml
+++ b/llm_benchmark/data/benchmark_models_2gb_ram.yml
@@ -3,4 +3,5 @@
 version: 1.0
 models:
   - model: qwen:1.8b
+  - model: gemma:2b
 

--- a/llm_benchmark/data/benchmark_models_2gb_ram.yml
+++ b/llm_benchmark/data/benchmark_models_2gb_ram.yml
@@ -4,5 +4,3 @@ version: 1.0
 models:
   - model: qwen:1.8b
   - model: phi:2.7b
-  - model: gemma:2b
-  - model: phi3:3.8b

--- a/llm_benchmark/data/benchmark_models_3gb_ram.yml
+++ b/llm_benchmark/data/benchmark_models_3gb_ram.yml
@@ -3,4 +3,7 @@
 version: 1.0
 models:
   - model: qwen:1.8b
+  - model: phi:2.7b
+  - model: phi3:3.8b
+  - model: gemma:2b
 

--- a/llm_benchmark/data/benchmark_models_8gb_ram.yml
+++ b/llm_benchmark/data/benchmark_models_8gb_ram.yml
@@ -2,6 +2,8 @@
 # License: MIT
 version: 1.0
 models:
+  - model: qwen:1.8b
+  - model: phi:2.7b
   - model: gemma:2b
   - model: gemma:7b
   - model: mistral:7b

--- a/llm_benchmark/main.py
+++ b/llm_benchmark/main.py
@@ -31,7 +31,9 @@ def run(ollamabin: str = 'ollama' , sendinfo : bool = True ):
 
     ft_mem_size = float(f"{sys_info['memory']:.2f}")
     models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_16gb_ram.yml')
-    if(ft_mem_size>=4 and ft_mem_size <7):
+    if(ft_mem_size>=1 and ft_mem_size <4):
+        models_file_path = pkg_resourses.resource_filename('llm_benchmark','data/benchmark_models_2gb_ram.yml')
+    elif(ft_mem_size>=4 and ft_mem_size <7):
         models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_4gb_ram.yml')
     elif(ft_mem_size>=7 and ft_mem_size <15):
         models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_8gb_ram.yml')

--- a/llm_benchmark/main.py
+++ b/llm_benchmark/main.py
@@ -31,8 +31,10 @@ def run(ollamabin: str = 'ollama' , sendinfo : bool = True ):
 
     ft_mem_size = float(f"{sys_info['memory']:.2f}")
     models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_16gb_ram.yml')
-    if(ft_mem_size>=1 and ft_mem_size <4):
+    if(ft_mem_size>=1 and ft_mem_size <2):
         models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_2gb_ram.yml')
+    elif(ft_mem_size>=2 and ft_mem_size <4):
+        models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_3gb_ram.yml')
     elif(ft_mem_size>=4 and ft_mem_size <7):
         models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_4gb_ram.yml')
     elif(ft_mem_size>=7 and ft_mem_size <15):

--- a/llm_benchmark/main.py
+++ b/llm_benchmark/main.py
@@ -32,7 +32,7 @@ def run(ollamabin: str = 'ollama' , sendinfo : bool = True ):
     ft_mem_size = float(f"{sys_info['memory']:.2f}")
     models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_16gb_ram.yml')
     if(ft_mem_size>=1 and ft_mem_size <4):
-        models_file_path = pkg_resourses.resource_filename('llm_benchmark','data/benchmark_models_2gb_ram.yml')
+        models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_2gb_ram.yml')
     elif(ft_mem_size>=4 and ft_mem_size <7):
         models_file_path = pkg_resources.resource_filename('llm_benchmark','data/benchmark_models_4gb_ram.yml')
     elif(ft_mem_size>=7 and ft_mem_size <15):


### PR DESCRIPTION
Thanks for this straightforward benchmarking tool for ollama. 

As small systems with low amount of memory, but added NPUs are on the horizon, slightly adjusted the scripts to allow either systems with 4gb or lower, as well as a super low-mem variant of just 2gb ram. 

This also helps to measure the smallest GPUs performance measurement without getting penalties due to cpu/gpu workload splits. 

I will add a few comments with results of various machine combinations, include Raspberry PIs. 

I never uploaded them, as additional model variants were added and I don't know how your backend will react. 

 
 