### PR TITLE
#28 add support for Ollama host

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,13 @@ llm_benchmark run --no-sendinfo
 llm_benchmark run --ollamabin=~/code/ollama/ollama
 ```
 
-### Example #4 run custom benchmark models
+### Example #4 set an explicit Ollama HTTP host
+
+```bash
+llm_benchmark run --host=http://127.0.0.1:11434
+```
+
+### Example #5 run custom benchmark models
 
 1. Create a custom benchmark file like following yaml format, replace with your own benchmark models, remember to use double quote for your model name
 

--- a/llm_benchmark/check_ollama.py
+++ b/llm_benchmark/check_ollama.py
@@ -1,4 +1,8 @@
 import subprocess
+import json
+from urllib.parse import urlparse
+import ollama
+import requests
 
 def run_command(command):
     try:
@@ -16,6 +20,12 @@ def check_ollama_version(ollamabin='ollama'):
         return ans[-1][27:]
     else:
         return ans[-1][18:]
+
+def check_ollama_version_host(host: str):
+    response = requests.get(f"{host}/api/version")
+    if response.status_code == 200:
+        data = response.json()
+        return data.get('version', 'unknown')
 
 if __name__ == "__main__":
     check_ollama_version()

--- a/llm_benchmark/check_ollama.py
+++ b/llm_benchmark/check_ollama.py
@@ -1,7 +1,5 @@
 import subprocess
-import json
 from urllib.parse import urlparse
-import ollama
 import requests
 
 def run_command(command):

--- a/llm_benchmark/main.py
+++ b/llm_benchmark/main.py
@@ -9,9 +9,6 @@ from .security_connection import connection
 
 from importlib.resources import files
 
-import base64
-
-
 app = typer.Typer()
 
 @app.command()

--- a/llm_benchmark/run_benchmark.py
+++ b/llm_benchmark/run_benchmark.py
@@ -1,8 +1,10 @@
 import argparse
+import base64
 import yaml
 import subprocess
 import datetime
 from importlib.resources import files
+import ollama
 
 parser = argparse.ArgumentParser(
     prog="python3 check_models.py",
@@ -30,6 +32,10 @@ parser.add_argument("-t",
                     type=str,
                     help="provide benchmark model type. ex, instruct")
 
+parser.add_argument("--host",
+                    type=str,
+                    help="optional ollama http host, ex. http://127.0.0.1:11434")
+
 
 def parse_yaml(yaml_file_path):
     with open(yaml_file_path, 'r') as stream:
@@ -40,13 +46,29 @@ def parse_yaml(yaml_file_path):
             print(e)
     return data
 
-def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 'ollama'):
-    
+def _encode_images(image_paths: list[str] | None):
+    if not image_paths:
+        return None
+    encoded = []
+    for path in image_paths:
+        with open(path, 'rb') as image_file:
+            encoded.append(base64.b64encode(image_file.read()).decode('utf-8'))
+    return encoded
+
+def _eval_rate_from_response(response: dict) -> float | None:
+    eval_count = response.get('eval_count')
+    eval_duration = response.get('eval_duration')
+    if not eval_count or not eval_duration:
+        return None
+    return (eval_count * 1_000_000_000) / eval_duration
+
+def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 'ollama', host: str | None = None):
+
     models_dict = parse_yaml(models_file_path)
     benchmark_dict = parse_yaml(benchmark_file_path)
     model_type = type
     allowed_models = {e['model'] for e in models_dict['models']}
-    
+
     ans={}
     if (model_type=='custom-model'):
         print("Running custom-model")
@@ -58,7 +80,9 @@ def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 
                         one_model_type['models'] = []
                     one_model_type['models'].append(model)
 
-    # Writing to file        
+    client = ollama.Client(host=host) if host else None
+
+    # Writing to file
     for one_model_type in benchmark_dict['modeltypes']:
         #print(one_model_type)
         if (one_model_type['type']==model_type):
@@ -73,7 +97,7 @@ def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 
                         model_name = onemodel['model']
                         print(f'model_name =    {model_name}')
                         file1.write(f'\nmodel_name =    {model_name}\n')
-                        
+
                         if model_name.startswith('llava'):
                             for one_prompt in one_model_type['prompts']:
                                 img_file_names = one_prompt['keywords'].split(',')
@@ -81,34 +105,59 @@ def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 
                                     img_file_path = str(files('llm_benchmark').joinpath(f'data/img/{img}'))
                                     prompt = f"{one_prompt['prompt']} {img_file_path}"
                                     print(f"prompt = {prompt}")
+                                    if client:
+                                        response = client.generate(
+                                            model=model_name,
+                                            prompt=one_prompt['prompt'],
+                                            images=_encode_images([img_file_path]),
+                                            stream=False
+                                        )
+                                        file1.write(str(response))
+                                        number = _eval_rate_from_response(response)
+                                        if number is not None:
+                                            print(f"eval rate: {number:.2f} tokens/s")
+                                            stored_nums.append(number)
+                                    else:
+                                        result = subprocess.run([ollamabin, 'run', model_name, one_prompt['prompt'],'--verbose'], capture_output=True, text=True, check=True, encoding='utf-8')
+                                        std_err = result.stderr
+                                        #print(result.stderr)
+                                        file1.write(std_err)
+
+                                        for line in std_err.split('\n'):
+                                            if ('eval rate' in line) and ('prompt' not in line):
+                                                print(line)
+                                                number = float(line[-20:-8])
+                                                stored_nums.append(number)
+                                                #print(number)
+                        else:
+                            for one_prompt in one_model_type['prompts']:
+                                print(f"prompt = {one_prompt['prompt']}")
+                                if client:
+                                    response = client.generate(
+                                        model=model_name,
+                                        prompt=one_prompt['prompt'],
+                                        stream=False
+                                    )
+                                    file1.write(str(response))
+                                    number = _eval_rate_from_response(response)
+                                    if number is not None:
+                                        print(f"eval rate: {number:.2f} tokens/s")
+                                        stored_nums.append(number)
+                                else:
                                     result = subprocess.run([ollamabin, 'run', model_name, one_prompt['prompt'],'--verbose'], capture_output=True, text=True, check=True, encoding='utf-8')
                                     std_err = result.stderr
                                     #print(result.stderr)
                                     file1.write(std_err)
-                                    
+
                                     for line in std_err.split('\n'):
                                         if ('eval rate' in line) and ('prompt' not in line):
                                             print(line)
                                             number = float(line[-20:-8])
                                             stored_nums.append(number)
                                             #print(number)
-                        else:
-                            for one_prompt in one_model_type['prompts']:
-                                print(f"prompt = {one_prompt['prompt']}")
-                                result = subprocess.run([ollamabin, 'run', model_name, one_prompt['prompt'],'--verbose'], capture_output=True, text=True, check=True, encoding='utf-8')
-                                std_err = result.stderr
-                                #print(result.stderr)                                   
-                                file1.write(std_err)                                    
-                                
-                                for line in std_err.split('\n'):
-                                    if ('eval rate' in line) and ('prompt' not in line):
-                                        print(line)
-                                        number = float(line[-20:-8])
-                                        stored_nums.append(number)
-                                        #print(number)
 
-                        print("-"*20) 
-                        if(len(stored_nums)!=0):       
+                        print("-"*20)
+                        if(len(stored_nums)!=0):
                             average = sum(stored_nums)/len(stored_nums)
                             print("Average of eval rate: ", round(average,3), " tokens/s")
                             ans[f"{model_name}"]=f"{round(average,3):.2f}"
@@ -116,14 +165,13 @@ def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 
                         print("-"*40)
                         file1.write("\n"+"-"*40)
                     file1.close()
-                    
+
     return ans
 
-if __name__ == "__main__": 
+if __name__ == "__main__":
     args = parser.parse_args()
     #print(f"args.verbose value：{args.verbose}")
     if (args.models is not None) and (args.benchmark is not None) and (args.type is not None):
-        run_benchmark(args.models, args.benchmark, args.type, args.ollamabin)
+        run_benchmark(args.models, args.benchmark, args.type, args.ollamabin, args.host)
         print('-'*40)
-        
-        
+

--- a/llm_benchmark/run_benchmark_one.py
+++ b/llm_benchmark/run_benchmark_one.py
@@ -2,6 +2,7 @@ import argparse
 import yaml
 import subprocess
 import datetime
+import ollama
 
 parser = argparse.ArgumentParser(
     prog="python3 check_models.py",
@@ -19,6 +20,10 @@ parser.add_argument("-m",
                     type=str,
                     help="provide benchmark models YAML file path. ex. ../data/benchmark_models.yml")
 
+parser.add_argument("--host",
+                    type=str,
+                    help="optional ollama http host, ex. http://127.0.0.1:11434")
+
 def parse_yaml(yaml_file_path):
     with open(yaml_file_path, 'r') as stream:
         try:
@@ -28,13 +33,14 @@ def parse_yaml(yaml_file_path):
             print(e)
     return data
 
-if __name__ == "__main__": 
+if __name__ == "__main__":
     args = parser.parse_args()
     #print(f"args.verbose value：{args.verbose}")
     if (args.models is not None):
         #print(f"args.models file path：{args.models}")
         models_dict = parse_yaml(args.models)
-        
+        client = ollama.Client(host=args.host) if args.host else None
+
         loc_dt = datetime.datetime.today()
         # Writing to file
         with open(f'log_{loc_dt.strftime("%Y-%m-%d-%H%M%S")}.log', "w") as file1:
@@ -42,18 +48,32 @@ if __name__ == "__main__":
                 model_name = onemodel['model']
                 print(f'model_name =    {model_name}')
                 file1.write(f'\nmodel_name =    {model_name}\n')
-                
-                result = subprocess.run(['ollama', 'run', model_name,f'"Why is the sky blue?"','--verbose'], capture_output=True, text=True, check=True)
-                std_err = result.stderr
-                #print(result.stderr)
-                file1.write(std_err)
-                
-                for line in std_err.split('\n'):
-                    if ('eval rate' in line) and ('prompt' not in line):
-                        print(line)
-                        number = float(line[-20:-8])
-                        print(number)
-                        
-                
+
+                if client:
+                    response = client.generate(
+                        model=model_name,
+                        prompt="Why is the sky blue?",
+                        stream=False
+                    )
+                    file1.write(str(response))
+                    eval_count = response.get('eval_count')
+                    eval_duration = response.get('eval_duration')
+                    if eval_count and eval_duration:
+                        rate = (eval_count * 1_000_000_000) / eval_duration
+                        print(f"eval rate: {rate:.2f} tokens/s")
+                        print(rate)
+                else:
+                    result = subprocess.run(['ollama', 'run', model_name,f'"Why is the sky blue?"','--verbose'], capture_output=True, text=True, check=True)
+                    std_err = result.stderr
+                    #print(result.stderr)
+                    file1.write(std_err)
+
+                    for line in std_err.split('\n'):
+                        if ('eval rate' in line) and ('prompt' not in line):
+                            print(line)
+                            number = float(line[-20:-8])
+                            print(number)
+
+
                 print("-"*40)
                 file1.write("\n"+"-"*40)


### PR DESCRIPTION
This pull request adds support for specifying a custom Ollama HTTP host when running benchmarks, allowing users to interact with a remote Ollama server instead of relying solely on the local Ollama binary. The changes update the CLI, documentation, and internal logic to use the specified host for model management and benchmarking when provided. The code now conditionally uses the Ollama Python client or falls back to subprocess calls as appropriate.

closes #28 