### PR TITLE
fix: explicitly stop models to prevent concurrent loading errors

### DIFF
--- a/llm_benchmark/run_benchmark.py
+++ b/llm_benchmark/run_benchmark.py
@@ -116,7 +116,8 @@ def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 
                         print("-"*40)
                         file1.write("\n"+"-"*40)
                     file1.close()
-                    
+                    print (f"Stopping model {model_name}")
+                    subprocess.run([ollamabin, 'stop', model_name], capture_output=False, text=True, check=True, encoding='utf-8')                    
     return ans
 
 if __name__ == "__main__": 
@@ -126,4 +127,5 @@ if __name__ == "__main__":
         run_benchmark(args.models, args.benchmark, args.type, args.ollamabin)
         print('-'*40)
         
+
         

--- a/llm_benchmark/run_benchmark.py
+++ b/llm_benchmark/run_benchmark.py
@@ -117,7 +117,7 @@ def run_benchmark(models_file_path, benchmark_file_path, type, ollamabin: str = 
                         file1.write("\n"+"-"*40)
                     file1.close()
                     print (f"Stopping model {model_name}")
-                    subprocess.run([ollamabin, 'stop', model_name], capture_output=False, text=True, check=True, encoding='utf-8')                    
+                    subprocess.run([ollamabin, 'stop', model_name], capture_output=False, text=True, check=False, encoding='utf-8')                    
     return ans
 
 if __name__ == "__main__": 
@@ -129,3 +129,4 @@ if __name__ == "__main__":
         
 
         
+


### PR DESCRIPTION
Explicitly calls ollama stop after each run to ensure memory is freed. This prevents the benchmark from failing on systems where Ollama attempts to load multiple models simultaneously, which otherwise leads to resource exhaustion and prevents completion.